### PR TITLE
Modified rock_status

### DIFF
--- a/playbooks/files/rock_status
+++ b/playbooks/files/rock_status
@@ -20,8 +20,6 @@ function feature_enabled() {
 
 @test "Check each monitor interface is live" {
   local timeout_sec=5
-  local timeout_pkt=5
-  local results=()
 
   # Timeout after 5 seconds or 5 packets
   for interface in $MON_IFS; do
@@ -49,7 +47,7 @@ function feature_enabled() {
     echo "WARNING: Monitor interface ${interface} has sent ${pkts} packets."
     echo "Minimal packets pasted on startup may be due to IPV6 at the kernal."
     echo "Disable IPv6 on the interface at the kernel layer."
-    [ $pkts -lt 0 ]
+    [ $pkts -eq 0 ]
   done
 }
 


### PR DESCRIPTION
Removed two unused variables.
Changed a logic test from checking for a negative number of packets transmitted (which with always fail) to checking to ensure that 0 packets have been transmitted from the monitoring interface.
(Note: In my discussions with others, it seems a monitoring interface may occasionally send an odd packet or two, so checking to ensure the number is zero may be too strict of a test.)