### PR TITLE
Fixed #37 by using  include_vars for rocknsm config

### DIFF
--- a/playbooks/sensors.yml
+++ b/playbooks/sensors.yml
@@ -2,6 +2,10 @@
 
 - hosts: sensors
 
+  pre_tasks:
+    - name: Apply override settings, if available
+      include_vars: /etc/rocknsm/config.yml
+
   roles:
     - common_sensor
     - { role: suricata, when: with_suricata }

--- a/playbooks/servers.yml
+++ b/playbooks/servers.yml
@@ -2,6 +2,10 @@
 
 - hosts: servers
 
+  pre_tasks:
+    - name: Apply override settings, if available
+      include_vars: /etc/rocknsm/config.yml
+
   roles:
     - { role: elasticsearch, when: with_elasticsearch }
     - { role: logstash, when: with_logstash }


### PR DESCRIPTION
The playbooks/sensors.yml and playbooks/servers.yml were both missing the following line:

include_vars: /etc/rocknsm/config.yml

Simply adding this as a task didn’t fix the problem because the order of execution when using roles. After reading http://docs.ansible.com/ansible/latest/playbooks_reuse_roles.html it was clear that pre_tasks must be used in order to be processed before roles.

For referference, the include_vars config was in the playbooks/all.yml file, but was not in the other files.

To fix the problem, added the pre_tasks to load the variables so they would be loaded when processing the playbook